### PR TITLE
Parallel numba

### DIFF
--- a/hadrons/example_continuous_beam_backend.py
+++ b/hadrons/example_continuous_beam_backend.py
@@ -9,13 +9,19 @@ import pandas as pd
 import seaborn as sns
 from functions import IonTracks_continuous_beam
 
+
 def main():
     # Parse backend argument
     if len(sys.argv) > 1:
         backend = sys.argv[1].lower()
     else:
         backend = "cython"
-
+    args = {}
+    if len(sys.argv) > 2:
+        try:
+            args['myseed'] = int(sys.argv[2])
+        except:
+            raise ValueError("seed should be a number")
     # set parameters
     data_dict = dict(
         electrode_gap_cm=[0.1],
@@ -46,6 +52,7 @@ def main():
             particle=data.particle,
             doserate_Gy_min=data.doserate_Gy_min,
             backend=backend,
+            **args
         )
         IonTracks_df = pd.concat([IonTracks_df, result_df], ignore_index=True)
         results_str += f"Step {idx}\n"

--- a/hadrons/functions.py
+++ b/hadrons/functions.py
@@ -291,6 +291,10 @@ def IonTracks_continuous_beam(
         from hadrons.python.continuous_beam import continuous_beam_PDEsolver
     elif backend == "numba":
         from hadrons.numba_files.continuous_beam_numba import continuous_beam_PDEsolver
+    elif backend == "parallel":
+        from hadrons.parallel.continuous_beam_numba_parallel import (
+            continuous_beam_PDEsolver,
+        )
     else:
         raise ValueError(f"Unsupported backend: {backend}")
 


### PR DESCRIPTION
# What was added
- Was added implemantation of numba with parallelizm
- Was added measuring time of execution parts of code
- added implementation to backend_example

# Tests
Testing data:
electrode_gap_cm=[0.1, 0.2],
        particle=["proton", "carbon"],
        voltage_V=[300],
        E_MeV_u=[58.4],
        doserate_Gy_min=[7.2, 24, 3480],
Also tests were making on random seed = 2025
[IonTracks_results_parallel_20250610_151603.txt](https://github.com/user-attachments/files/20673765/IonTracks_results_parallel_20250610_151603.txt)
[IonTracks_results_numba_20250610_151103.txt](https://github.com/user-attachments/files/20673767/IonTracks_results_numba_20250610_151103.txt)

As you can see in this example we get the same results and when we use parallelizm we get speed-up around 50% comparing to sequential numba