### PR TITLE
Comparison of the results for the same seed

### DIFF
--- a/hadrons/cython_files/continuous_beam.pyx
+++ b/hadrons/cython_files/continuous_beam.pyx
@@ -35,8 +35,8 @@ def continuous_beam_PDEsolver(dict parameter_dic, dict extra_params_dic):
     
     cdef double track_radius    = extra_params_dic["track_radius_cm"]   # Gaussian radius b [cm]
     cdef bint SHOW_PLOT         = extra_params_dic["SHOW_PLOT"]         # show frames of the simulation
-    cdef int seed               = extra_params_dic["seed"]              # ensure the coordinates are sampled anew each run
-    rnd.seed(seed)                                                      # set the new seed
+    cdef int seed               = extra_params_dic["seed"]
+    cdef object rng             = rnd.default_rng(seed)  # Use Generator for reproducibility
     cdef bint PRINT             = extra_params_dic["PRINT_parameters"]  # print parameters?
 
     cdef double unit_length_cm  = extra_params_dic["unit_length_cm"]    # cm, size of every voxel length
@@ -161,7 +161,7 @@ def continuous_beam_PDEsolver(dict parameter_dic, dict extra_params_dic):
     The tracks are distributed uniformly in time
     '''
     cdef double time_s = computation_time_steps * dt
-    cdef np.ndarray[DTYPE_t, ndim=1] randomized = rnd.random(number_of_tracks)
+    cdef np.ndarray[DTYPE_t, ndim=1] randomized = rng.random(number_of_tracks)
     cdef np.ndarray[DTYPE_t, ndim=1] summed = np.cumsum(randomized)
     cdef np.ndarray[DTYPE_t, ndim=1] distributed_times = np.asarray(summed)/max(summed) * time_s
     cdef np.ndarray[DTYPE_t, ndim=1] bins = np.arange(0.0, time_s + dt, dt)

--- a/hadrons/example_continuous_beam_backend.py
+++ b/hadrons/example_continuous_beam_backend.py
@@ -1,4 +1,6 @@
+import argparse
 import itertools
+import os
 import sys
 import time
 from datetime import datetime
@@ -10,11 +12,12 @@ import seaborn as sns
 from functions import IonTracks_continuous_beam
 
 def main():
-    # Parse backend argument
-    if len(sys.argv) > 1:
-        backend = sys.argv[1].lower()
-    else:
-        backend = "cython"
+    parser = argparse.ArgumentParser(description="Run IonTracks continuous beam example with backend and seed selection.")
+    parser.add_argument("backend", nargs="?", default="cython", help="Backend to use: cython, python, numba")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for reproducibility")
+    args = parser.parse_args()
+    backend = args.backend.lower()
+    myseed = args.seed
 
     # set parameters
     data_dict = dict(
@@ -33,7 +36,6 @@ def main():
     # Prepare output file for stepwise results
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     artifacts_dir = "../artifacts"
-    import os
     os.makedirs(artifacts_dir, exist_ok=True)
     filename = os.path.join(artifacts_dir, f"IonTracks_results_{backend}_{timestamp}.txt")
     IonTracks_df = pd.DataFrame()
@@ -46,6 +48,7 @@ def main():
             particle=data.particle,
             doserate_Gy_min=data.doserate_Gy_min,
             backend=backend,
+            myseed=myseed,
         )
         IonTracks_df = pd.concat([IonTracks_df, result_df], ignore_index=True)
         results_str += f"Step {idx}\n"

--- a/hadrons/numba_files/continuous_beam_numba.py
+++ b/hadrons/numba_files/continuous_beam_numba.py
@@ -21,7 +21,7 @@ def continuous_beam_PDEsolver(parameter_dic, extra_params_dic):
     track_radius    = extra_params_dic["track_radius_cm"]   # Gaussian radius b [cm]
     SHOW_PLOT         = extra_params_dic["SHOW_PLOT"]         # show frames of the simulation
     seed               = extra_params_dic["seed"]              # ensure the coordinates are sampled anew each run
-    np.random.seed(seed)                                                      # set the new seed
+    rng = np.random.default_rng(seed)  # Use Generator for reproducibility
     PRINT             = extra_params_dic["PRINT_parameters"]  # print parameters?
 
     unit_length_cm  = extra_params_dic["unit_length_cm"]    # cm, size of every voxel length
@@ -88,8 +88,8 @@ def continuous_beam_PDEsolver(parameter_dic, extra_params_dic):
     Gaussian_factor = N0/(pi*b_cm**2)
 
     # preallocate arrays
-    x_coordinates_ALL = np.random.uniform(0, 1, int(number_of_iterations))*no_xy
-    y_coordinates_ALL = np.random.uniform(0, 1, int(number_of_iterations))*no_xy
+    x_coordinates_ALL = rng.uniform(0, 1, int(number_of_iterations))*no_xy
+    y_coordinates_ALL = rng.uniform(0, 1, int(number_of_iterations))*no_xy
     positive_array = np.zeros((no_xy, no_xy, no_z_with_buffer))
     negative_array = np.zeros((no_xy, no_xy, no_z_with_buffer))
     positive_array_temp = np.zeros((no_xy, no_xy, no_z_with_buffer))
@@ -145,7 +145,7 @@ def continuous_beam_PDEsolver(parameter_dic, extra_params_dic):
     '''
 
     time_s = computation_time_steps * dt
-    randomized = np.random.random(number_of_tracks)
+    randomized = rng.random(number_of_tracks)
     summed = np.cumsum(randomized)
     distributed_times = np.asarray(summed)/max(summed) * time_s
     bins = np.arange(0.0, time_s + dt, dt)


### PR DESCRIPTION
I've enforced cython and numba codes to use the same random number generator with identical seed. I performed 3 experiments. The results are not identical, but the difference between them is very small. I think they might be result of the floating point arithmetics. I attach the chart that shows the difference in calculation for 3 different seeds. Also I'm not sure if we should merge this.

![backend_difference_plot](https://github.com/user-attachments/assets/d36947f7-a942-4737-8923-bb7a40960981)
